### PR TITLE
Improve Makefile to avoid GCC 14 warnings and optimize more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,14 +119,14 @@ ASFLAGS := -mcpu=arm7tdmi --defsym MODERN=$(MODERN)
 
 ifeq ($(MODERN),0)
 CC1             := tools/agbcc/bin/agbcc$(EXE)
-override CFLAGS += -mthumb-interwork -Wimplicit -Wparentheses -Werror -O2 -fhex-asm -g
+override CFLAGS += -mthumb-interwork -Wimplicit -Wparentheses -Werror -O3 -fhex-asm -g
 ROM := $(ROM_NAME)
 OBJ_DIR := $(OBJ_DIR_NAME)
 LIBPATH := -L ../../tools/agbcc/lib
 LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
 else
 CC1              = $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
-override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -std=gnu17 -Werror -Wall -Wno-strict-aliasing -Wno-attribute-alias -Woverride-init
+override CFLAGS += -mthumb -mthumb-interwork -O3 -flto -ffat-lto-objects -Wno-error=maybe-uninitialized -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -std=gnu17 -Werror -Wall -Wno-strict-aliasing -Wno-attribute-alias -Woverride-init -Wno-error=array-bounds -Wno-error=stringop-overflow
 ifeq ($(ANALYZE),1)
 override CFLAGS += -fanalyzer
 endif
@@ -499,7 +499,11 @@ endif
 $(OBJ_DIR)/ld_script.ld: $(LD_SCRIPT) $(LD_SCRIPT_DEPS)
 	cd $(OBJ_DIR) && sed "s#tools/#../../tools/#g" ../../$(LD_SCRIPT) > ld_script.ld
 
+ifeq ($(MODERN),0)
 LDFLAGS = -Map ../../$(MAP)
+else
+LDFLAGS = -Map ../../$(MAP) -flto
+endif
 $(ELF): $(OBJ_DIR)/ld_script.ld $(OBJS) libagbsyscall
 	@echo "cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld -o ../../$@ <objects> <lib>"
 	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld --print-memory-usage -o ../../$@ $(OBJS_REL) $(LIB) | cat


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
DevKitARM is a fast moving target and the GCC 14 update in particular added many warnings and new errors that can make it impossible to compile. Given DevKitARM does not provide archived copies of the toolchain, supporting the latest is imperative. I've disabled a few warnings so the build completes on the latest DKA as of today.

I also noticed the game has a bit of overload in the interrupt handlers for audio that lead to audio crackle in mGBA and slowdown on real hardware. I've compiled the game with the third level of optimization (it was on the second), and enabled Link-Time Optimization. I've tested the game with these features enabled and did not run into issues. Instead, the crackle is gone and real hardware feels much snappier. This should prove to be a free speedup for the project! The third level of optimization is generally considered to be safe to ship these days -- it was once much more prone to issues but is now stable. It's only `-Ofast` that scares me anymore. LTO being enabled as well may lead to faster discovery of logical code errors such as invalid array indexing.

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->
https://tenor.com/Eq9X.gif

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
`@luigi___`
