### PR TITLE
Remove legacy AGBCC build and restore github action status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,21 +15,16 @@ jobs:
       GAME_VERSION: EMERALD
       GAME_REVISION: 0
       GAME_LANGUAGE: ENGLISH
-      MODERN: 0
       COMPARE: 0
-      UNUSED_ERROR: 1
+      UNUSED_ERROR: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Checkout agbcc
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          path: agbcc
-          repository: pret/agbcc
-        
+          clean: true
+
       - name: Checkout poryscript
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: poryscript
           repository: huderlem/poryscript
@@ -42,23 +37,15 @@ jobs:
         # gcc-arm-none-eabi is only needed for the modern build
         # as an alternative to dkP
 
-      - name: Install agbcc
-        run: |
-          ./build.sh
-          ./install.sh ../
-        working-directory: agbcc
-
       - name: Install poryscript
         run: |
           go build
           ./install.sh ../
         working-directory: poryscript
 
-      - name: Agbcc
-        env:
-          MODERN: 0
-          COMPARE: 0
-        run: make -j${nproc} -O all
+      - name: Hack poryscript configs
+        run: |
+          cp tools/poryscript/*.json .
 
       - name: Modern
         env:
@@ -66,10 +53,3 @@ jobs:
           COMPARE: 0
         run: make -j${nproc} -O all
 
-      - name: Test
-        env:
-          MODERN: 1
-          TEST: 1
-        run: |
-          make -j${nproc} -O pokescape-test.elf
-          make -j${nproc} check

--- a/Makefile
+++ b/Makefile
@@ -126,15 +126,9 @@ LIBPATH := -L ../../tools/agbcc/lib
 LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
 else
 CC1              = $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
-override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -std=gnu17 -Werror -Wall -Wno-strict-aliasing -Wno-attribute-alias -Woverride-init
+override CFLAGS += -mthumb -mthumb-interwork -O2 -Wno-error=maybe-uninitialized -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -std=gnu17 -Werror -Wall -Wno-strict-aliasing -Wno-attribute-alias -Woverride-init -Wno-error=array-bounds -Wno-error=stringop-overflow -Wno-error=unused-variable -Wno-error=unused-const-variable -Wno-error=unused-parameter -Wno-error=unused-function -Wno-error=unused-but-set-parameter -Wno-error=unused-but-set-variable -Wno-error=unused-value -Wno-error=unused-local-typedefs
 ifeq ($(ANALYZE),1)
 override CFLAGS += -fanalyzer
-endif
-# Only throw an error for unused elements if its RH-Hideout's repo
-ifeq ($(UNUSED_ERROR),0)
-ifneq ($(GITHUB_REPOSITORY_OWNER),rh-hideout)
-override CFLAGS += -Wno-error=unused-variable -Wno-error=unused-const-variable -Wno-error=unused-parameter -Wno-error=unused-function -Wno-error=unused-but-set-parameter -Wno-error=unused-but-set-variable -Wno-error=unused-value -Wno-error=unused-local-typedefs
-endif
 endif
 ROM := $(MODERN_ROM_NAME)
 OBJ_DIR := $(MODERN_OBJ_DIR_NAME)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
AGBCC is old and currently broken on these sources. Everyone uses modern GCC these days. RHH is removing support upstream. All signs point to removing these lines.

## **Discord contact info**
`@luigi___`
